### PR TITLE
Allows use of monthnumbers on links in the calendar.

### DIFF
--- a/Pyblosxom/plugins/pycalendar.py
+++ b/Pyblosxom/plugins/pycalendar.py
@@ -183,7 +183,10 @@ class PyblCalendar:
                 continue
 
             # mark the entry because it's one we want to show
-            datepiece = time.strftime("%Y/%b/%d", timetuple)
+            if config.get("static_monthnumbers"):
+                datepiece = time.strftime("%Y/%m/%d", timetuple)
+            else:
+                datepiece = time.strftime("%Y/%b/%d", timetuple)
             self._entries[day] = (baseurl + "/" + datepiece, day)
 
         # Set the first day of the week (Sunday by default)


### PR DESCRIPTION
I was using static_monthnumbers instead of static_monthnames and noticed that the links on the calendar were pointing to a monthname but I didn't have those files generated, so the links were pointing to non-existent pages.

This change attempts to fix that issue.

This is my first pull request by the way so I apologize if I'm not doing it correctly.
