### PR TITLE
Prevent registration of date key in entry metadata cache

### DIFF
--- a/Pyblosxom/entries/base.py
+++ b/Pyblosxom/entries/base.py
@@ -193,7 +193,7 @@ class EntryBase:
             # from the user metadata, rather than the value
             # derived from mtime.
             if data.has_key('date'):
-                data.pop(key)
+                data.pop('date')
             mycache[entryid] = data
 
     addToCache = tools.deprecated_function(add_to_cache)


### PR DESCRIPTION
This is a minimal patch to address a small glitch encountered in a local plugin that uses a #date metadata label. The string value was registering in the entry metadata cache, and the cache value apparently takes precedence over the formatted value derived from mtime. The result was an unformatted dates in post output. With this patch, that does not happen.

Arguably all keys in set_time() that derive their values from the timetuple should be set to block in this way, but this seems the most likely to be used in metadata.
