### PR TITLE
Fix RSS and Atom feeds in pages plugin

### DIFF
--- a/Pyblosxom/plugins/pages.py
+++ b/Pyblosxom/plugins/pages.py
@@ -236,7 +236,7 @@ def is_frontpage(pyhttp, config):
     if pathinfo == "/":
         return True
     path, ext = os.path.splitext(pathinfo)
-    if path == "/index":
+    if path == "/index" and not ext in [".rss20", ".atom", ".rss"]:
         return True
     return False
 


### PR DESCRIPTION
With the pages plugin, Pyblosxom was returning the static front page when a feed was requested. With this patch, feeds work normally.
