### PR TITLE
Fix RSS and Atom feeds in the pages plugin

### DIFF
--- a/Pyblosxom/plugins/pages.py
+++ b/Pyblosxom/plugins/pages.py
@@ -236,7 +236,7 @@ def is_frontpage(pyhttp, config):
     if pathinfo == "/":
         return True
     path, ext = os.path.splitext(pathinfo)
-    if path == "/index":
+    if path == "/index" and not ext in [".rss20", ".atom", ".rss"]:
         return True
     return False
 


### PR DESCRIPTION
RSS and Atom feeds were not working with the pages plugin. This fixes them.
