### PR TITLE
Fix config abuse in static rendering.

### DIFF
--- a/Pyblosxom/pyblosxom.py
+++ b/Pyblosxom/pyblosxom.py
@@ -398,7 +398,7 @@ class Pyblosxom:
             url = url.replace(os.sep, "/")
             print "rendering '%s' ..." % url
 
-            tools.render_url_statically(config, url, q)
+            tools.render_url_statically(dict(config), url, q)
 
         # we're done, clean up
         self.cleanup()


### PR DESCRIPTION
If a plugin abuses the config during static rendering, it'd affect
everything rendered after the changes have taken place. That's bad.
This fixes that so that each page is rendered with a copy of the
config.

Note: It's a shallow copy and not a deep copy so it's still possible
for plugins to do bad things, but that should be treated as a bug
in the plugin.
