### PR TITLE
Split static_flavours into two config vars

### DIFF
--- a/Pyblosxom/pyblosxom.py
+++ b/Pyblosxom/pyblosxom.py
@@ -268,6 +268,7 @@ class Pyblosxom:
             return 0
 
         flavours = config.get("static_flavours", ["html"])
+        index_flavours = config.get("static_index_flavours", ["html"])
 
         renderme = []
 
@@ -332,7 +333,7 @@ class Pyblosxom:
 
                 # toss in the render queue
                 for f in flavours:
-                    renderme.append( (mem + "." + f, "") )
+                    renderme.append((mem + "." + f, ""))
 
         print "rendering %d entries." % len(renderme)
 
@@ -350,7 +351,7 @@ class Pyblosxom:
 
         for mem in categories:
             mem = os.path.normpath(mem + "/index.")
-            for f in flavours:
+            for f in index_flavours:
                 renderme.append((mem + f, ""))
 
         # now we handle dates
@@ -363,7 +364,7 @@ class Pyblosxom:
 
         for mem in dates:
             mem = os.path.normpath(mem + "/index.")
-            for f in flavours:
+            for f in index_flavours:
                 renderme.append((mem + f, ""))
 
         # now we handle arbitrary urls

--- a/docs/deploy_staticrendering.rst
+++ b/docs/deploy_staticrendering.rst
@@ -49,7 +49,22 @@ These are the instructions for configuring static rendering in Pyblosxom.
 
       py["static_flavours"] = ["html"]
 
-3. (optional) Uncomment ``static_monthnames`` in your ``config.py`` file.
+3. (optional) Uncomment ``static_index_flavours`` in your ``config.py`` file.
+
+   ``static_index_flavours`` is just like ``static_flavours`` except
+   it's the flavours of the index files: frontpage index, category
+   indexes, date indexes, ...
+
+   Defaults to ``["html"]`` which only renders the html flavour.
+
+   For example::
+
+     py["static_index_flavours"] = ["html"]
+
+   If you want your index files to also be feeds, then you should add
+   a feed flavour to the list.
+
+4. (optional) Uncomment ``static_monthnames`` in your ``config.py`` file.
 
    The value (either ``True`` or ``False``) will determine if you want
    month names (such as ``April``) in the static pages.
@@ -60,7 +75,7 @@ These are the instructions for configuring static rendering in Pyblosxom.
 
       py["static_monthnames"] = False
 
-4. Uncomment ``static_monthnumbers`` in your ``config.py`` file.
+5. Uncomment ``static_monthnumbers`` in your ``config.py`` file.
 
    The value (either ``True`` or ``False``) will determine if you want
    month numbers (such as ``04`` for ``April``) in the static pages.
@@ -71,7 +86,7 @@ These are the instructions for configuring static rendering in Pyblosxom.
 
       py["static_monthnumbers"] = False
 
-5. Set ``base_url`` in your ``config.py`` file to the base url your 
+6. Set ``base_url`` in your ``config.py`` file to the base url your 
    blog will have.
 
    For example, if your ``static_dir`` were set to
@@ -86,6 +101,7 @@ Here's an example of static rendering configuration::
 
    py["static_dir"] = "/home/joe/public_html/static/"
    py["static_flavours"] = ["html"]
+   py["static_index_flavours"] = ["html", "atom"]
    py["static_monthnames"] = False    # I do not want month names
    py["static_monthnumbers"] = True   # I do want month numbers
 


### PR DESCRIPTION
For index files, I think it's common to want to render them in the
default flavour (usually html) and also in a feed flavour like
rss, atom, xml, etc. Given that, seems to make sense to break
"static_flavours" into two separate config variables:
1. "static_flavours" which is used for all content
2. "static_index_flavours" which is used for all archive and index
   urls

I made "static_index_flavours" default to ["html"] as well, figuring
that's the default of least surprise.
