### PR TITLE
Add python versions to classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content"
     ]


### PR DESCRIPTION
This specifies which versions of Python pyblosxom works with in the classifier section of setup.py so the PyPI metadata information is correct.
