### PR TITLE
Fix rst_parser to allow for pygments highlighting

### DIFF
--- a/Pyblosxom/plugins/rst_parser.py
+++ b/Pyblosxom/plugins/rst_parser.py
@@ -113,7 +113,8 @@ def _parse(initial_header_level, transform_doctitle, story):
         writer_name='html',
         settings_overrides={
             'initial_header_level': initial_header_level,
-            'doctitle_xform': transform_doctitle
+            'doctitle_xform': transform_doctitle,
+            'syntax_highlight': 'short'
             })
     return parts['body']
 


### PR DESCRIPTION
When doing static rendering, docutils would tell pygments to use the long class names rather than the short ones. I'm not really sure why, but this fixes that.
