### PR TITLE
Fix readmore plugin to denote it added a break

### DIFF
--- a/Pyblosxom/plugins/readmore.py
+++ b/Pyblosxom/plugins/readmore.py
@@ -217,4 +217,5 @@ def cb_story(args):
                         "file_path": file_path,
                         "flavour": flavour})
 
+    entry["just_summary"] = 1
     entry["body"] = entry["body"][:match.start()] + link


### PR DESCRIPTION
This tweaks the readmore plugin so that it mentions the fact that it just cut the blog entry in half. This is important since depending on how you render blog entries, you could be in the middle of a `<div>` block that you now need to close. This is probably a defect in the design. I'm not really sure what to do about it since the missing bits could be anything and could differ by context.

Anyhow, this "fix" smooths over that a bit and makes it possible to write a plugin to deal with it.
