### PR TITLE
Fix paginate query string parse exception

### DIFF
--- a/Pyblosxom/plugins/paginate.py
+++ b/Pyblosxom/plugins/paginate.py
@@ -200,7 +200,7 @@ def page(request, num_entries, entry_list):
             if form:
                 try:
                     page = int(form.getvalue("page"))
-                except ValueError:
+                except:
                     page = count_from
 
             # Restructure the querystring so that page= is at the end


### PR DESCRIPTION
While working on a new flavour I noticed a nasty exception I got as soon as I added ?flav=html to any URL. Apparently a change in the last commit to paginate.py was the culprit. The attached patch fixes the problem. 

Commit 52376c30da5 introduced a bug which resulted in a nasty exception
if the URL contained a query string without a page keyword.
