### PR TITLE
readmore.py - generate correct xhtml for abbreviated entry

### DIFF
--- a/Pyblosxom/plugins/readmore.py
+++ b/Pyblosxom/plugins/readmore.py
@@ -194,8 +194,15 @@ def cb_story(args):
     breakpoint = config.get("readmore_breakpoint", READMORE_BREAKPOINT)
     template = config.get("readmore_template", READMORE_TEMPLATE)
 
-    # check to see if the breakpoint is in the body.
-    match = re.search(breakpoint, entry["body"])
+    """
+    Check to see if the breakpoint is in the body.
+
+    Since it might have been wrapped in html tags by a markdown
+    plugin, grab everything from the end of breakpoint up to, but
+    excluding, either the first opening tag, or newline.
+    """
+    match = re.search('(' + breakpoint + ')(.*?)(<[ ]*?[^/].+|[\n])', \
+                      entry["body"])
 
     # if not, return because we don't have to do anything
     if not match:
@@ -222,4 +229,5 @@ def cb_story(args):
                         "flavour": flavour})
 
     entry["just_summary"] = 1
-    entry["body"] = entry["body"][:match.start()] + link
+    entry["body"] = entry["body"][:match.start(0)] + link + str(match.group(2))
+

--- a/Pyblosxom/plugins/readmore.py
+++ b/Pyblosxom/plugins/readmore.py
@@ -89,6 +89,8 @@ then you could have a blog entry like this::
       Ha ha!  Made you look below the break!
     </p>
 
+In order to produce valid HTML, the BREAK needs to be on a line of its
+own, i.e. not interspersed in text.
 
 Usage with rst_parser
 =====================
@@ -199,9 +201,13 @@ def cb_story(args):
 
     Since it might have been wrapped in html tags by a markdown
     plugin, grab everything from the end of breakpoint up to, but
-    excluding, either the first opening tag, or newline.
+    excluding, either the first opening tag, or newline. We assume
+    that all this tag wrapping will stay on the same line.
+
+    XXX We might insist on the breakpoint occurring on the beginning
+        of a line of its own.
     """
-    match = re.search('(' + breakpoint + ')(.*?)(<[ ]*?[^/].+|[\n])', \
+    match = re.search('(' + breakpoint + ')(.*?)(<[ ]*?[^/].+|[\n])',
                       entry["body"])
 
     # if not, return because we don't have to do anything

--- a/Pyblosxom/plugins/readmore.py
+++ b/Pyblosxom/plugins/readmore.py
@@ -229,5 +229,4 @@ def cb_story(args):
                         "flavour": flavour})
 
     entry["just_summary"] = 1
-    entry["body"] = entry["body"][:match.start(0)] + link + str(match.group(2))
-
+    entry["body"] = entry["body"][:match.start(1)] + link + str(match.group(2))

--- a/Pyblosxom/tests/test_readmore.py
+++ b/Pyblosxom/tests/test_readmore.py
@@ -33,21 +33,37 @@ class ReadmoreTest(PluginTest):
         # if showing a single file, then we nix the BREAK bit.
         req = Request({"base_url": "/"}, {}, {"bl_type": "file"})
 
-        args = {"entry": {"body": "no BREAK break",
+        args = {"entry": {"body": "no BREAK break\n",
                           "file_path": ""},
                 "request": req}
 
         readmore.cb_story(args)
-        self.assertEquals(args["entry"]["body"], "no  break")
+        self.assertEquals(args["entry"]["body"], "no  break\n")
 
-    def test_story_break_index(self):
+    def test_story_break_index_at_tag(self):
         # if showing the entry in an index, then we replace the BREAK
-        # with the template and nix everything after BREAK.
+        # with the template and nix everything from the first opening
+        # html tag after BREAK.
         req = Request({"readmore_template": "FOO", "base_url": "/"},
                       {},
                       {"bl_type": "dir"})
 
-        args = {"entry": {"body": "no BREAK break",
+        args = {"entry": {"body": "no BREAK<p> break",
+                          "file_path": ""},
+                "request": req}
+
+        readmore.cb_story(args)
+        self.assertEquals(args["entry"]["body"], "no FOO")
+
+    def test_story_break_index_at_eol(self):
+        # if showing the entry in an index, then we replace the BREAK
+        # with the template and nix everything from the first newline
+        # after BREAK.
+        req = Request({"readmore_template": "FOO", "base_url": "/"},
+                      {},
+                      {"bl_type": "dir"})
+
+        args = {"entry": {"body": "no BREAK\n break",
                           "file_path": ""},
                 "request": req}
 


### PR DESCRIPTION
The breakpoint might have been wrapped in html tags by a markdown plugin.

Instead of blindly truncating the body from the breakpoint marker on,
we grab everything from the end of breakpoint up to, but excluding,
either the first opening tag, or newline.

Should fix Pyblosxom issue #49 .