### PR TITLE
Fix AJAX comment posting

### DIFF
--- a/Pyblosxom/tests/test_comments.py
+++ b/Pyblosxom/tests/test_comments.py
@@ -419,12 +419,6 @@ class TestComments(PluginTest):
         # a comment that was just posted
         self.set_form_data({'ajax': 'post'})
         self.assertEquals(False, should_output('story'))
-
-        self.entry['cmt_time'] = self.timestamp
-        self.assert_('cmt_time' not in self.data)
-        self.assertEquals(False, should_output('comment'))
-
-        self.data['cmt_time'] = self.timestamp
         self.assertEquals(True, should_output('comment'))
 
     def test_num_comments(self):


### PR DESCRIPTION
I never really liked the way AJAX comments worked. In case of a
successful upload all the comments got rendered and checked via the
timestamp. This change returns a dynamically created comment which
simplifies the code a lot.