### PR TITLE
A few changes to fix pyblosxom-cmd staticrender --incremental in python3

### DIFF
--- a/Pyblosxom/blosxom.py
+++ b/Pyblosxom/blosxom.py
@@ -2,6 +2,7 @@ import locale
 import os
 import sys
 import time
+import operator
 from Pyblosxom import tools
 from Pyblosxom.entries.fileentry import FileEntry
 
@@ -252,7 +253,9 @@ def blosxom_sort_list_handler(args):
     entry_list = args["entry_list"]
 
     entry_list = [(e._mtime, e) for e in entry_list]
-    entry_list.sort()
+    # Sort only by first element. Second element is a FileEntry
+    # and doesn't support comparison operators.
+    entry_list.sort(key = operator.itemgetter(0))
     entry_list.reverse()
     entry_list = [e[1] for e in entry_list]
 

--- a/Pyblosxom/commandline.py
+++ b/Pyblosxom/commandline.py
@@ -416,7 +416,7 @@ def run_static_renderer(command, argv):
     (options, args) = parser.parse_args()
 
     # Turn on memcache.
-    from .Pyblosxom import memcache
+    from Pyblosxom import memcache
     memcache.usecache = True
 
     p = build_pyblosxom()


### PR DESCRIPTION
On the python3 branch, I needed to make small changes to two files to get pyblosxom-cmd staticrender --incremental working.