### PR TITLE
Akk

### DIFF
--- a/Pyblosxom/crashhandling.py
+++ b/Pyblosxom/crashhandling.py
@@ -18,10 +18,10 @@ This module has the code for handling crashes.
 
 import sys
 import io
-import cgi
+import html
 import traceback
 
-_e = cgi.escape
+_e = html.escape
 
 
 class Response:

--- a/Pyblosxom/plugins/disqus.py
+++ b/Pyblosxom/plugins/disqus.py
@@ -47,15 +47,15 @@ comment_form template::
         var dsq = document.createElement('script');
         dsq.type = 'text/javascript';
         dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] ||
          document.getElementsByTagName('body')[0]).appendChild(dsq);
       })();
     </script>
     <noscript>Please enable JavaScript to view the
-      <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a>
+      <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a>
     </noscript>
-    <a href="http://disqus.com" class="dsq-brlink"
+    <a href="https://disqus.com" class="dsq-brlink"
       >blog comments powered by <span class="logo-disqus">Disqus</span></a>
 """
 

--- a/Pyblosxom/plugins/pycalendar.py
+++ b/Pyblosxom/plugins/pycalendar.py
@@ -96,7 +96,6 @@ class PyblCalendar:
 
         self._entries = {}
 
-    @memcache_decorator('pycalendar', True)
     def __str__(self):
         """
         Returns the on-demand generated string.
@@ -133,9 +132,7 @@ class PyblCalendar:
         # this comes in as '', 2001, 2002, 2003, ...  so we can convert it
         # without an issue
         temp = data.get("pi_yr")
-        if not temp:
-            view[0] = int(self._today[0])
-        else:
+        if temp:
             view[0] = int(temp)
 
         # the month is a bit harder since it can come in as "08", "", or
@@ -145,8 +142,6 @@ class PyblCalendar:
             view[1] = int(temp)
         elif temp and temp in tools.month2num:
             view[1] = int(tools.month2num[temp])
-        else:
-            view[1] = int(self._today[1])
 
         self._view = view = tuple(view)
 

--- a/Pyblosxom/pyblosxom.py
+++ b/Pyblosxom/pyblosxom.py
@@ -109,7 +109,12 @@ class Pyblosxom:
         # entryparser callback is run here first to allow other
         # plugins register what file extensions can be used
         data['extensions'] = tools.run_callback("entryparser",
-                                                {'txt': blosxom_entry_parser},
+                                                # Use blx instead of txt
+                                                # as the file extension
+                                                # for entries, since they
+                                                # aren't text, they're HTML.
+                                                {'blx': blosxom_entry_parser},
+                                                # {'txt': blosxom_entry_parser},
                                                 mappingfunc=lambda x, y: y,
                                                 defaultfunc=lambda x: x)
 


### PR DESCRIPTION
Fixes pyblosxom/pyblosxom#56

In the pycalendar plug-in, when running a staticrender without --incremental, the date on individual posts was wrong: it was the date of the staticrender, not the date of the post. This was partly due to the use of memcache_decorator on the calendar (once it was generated for the first file, it was kept forever and never updated) and partly due to replacing values like pi_yr, pi_mo that were passed in from the post with today's date.
