### PR TITLE
Fix a locale error, and make entry file extension optional

### DIFF
--- a/Pyblosxom/blosxom.py
+++ b/Pyblosxom/blosxom.py
@@ -79,8 +79,8 @@ def blosxom_handler(request):
     data["latest_date"] = time.strftime('%a, %d %b %Y', mtime_tuple)
 
     # Make sure we get proper 'English' dates when using standards
-    loc = locale.getlocale(locale.LC_ALL)
-    locale.setlocale(locale.LC_ALL, 'C')
+    loc = locale.getlocale(locale.LC_TIME)
+    locale.setlocale(locale.LC_TIME, 'C')
 
     data["latest_w3cdate"] = time.strftime('%Y-%m-%dT%H:%M:%SZ',
                                            mtime_gmtuple)
@@ -88,7 +88,7 @@ def blosxom_handler(request):
                                               mtime_gmtuple)
 
     # set the locale back
-    locale.setlocale(locale.LC_ALL, loc)
+    locale.setlocale(locale.LC_TIME, loc)
 
     # we pass the request with the entry_list through the prepare
     # callback giving everyone a chance to transform the data.  the

--- a/Pyblosxom/pyblosxom.py
+++ b/Pyblosxom/pyblosxom.py
@@ -108,13 +108,10 @@ class Pyblosxom:
 
         # entryparser callback is run here first to allow other
         # plugins register what file extensions can be used
+        entry_ext = config.get("entryext", ".txt")
         data['extensions'] = tools.run_callback("entryparser",
-                                                # Use blx instead of txt
-                                                # as the file extension
-                                                # for entries, since they
-                                                # aren't text, they're HTML.
-                                                {'blx': blosxom_entry_parser},
-                                                # {'txt': blosxom_entry_parser},
+                                                {entry_ext:
+                                                   blosxom_entry_parser},
                                                 mappingfunc=lambda x, y: y,
                                                 defaultfunc=lambda x: x)
 


### PR DESCRIPTION
locale.getlocale(locale.LC_ALL) was failing with: "TypeError('category LC_ALL is not supported')"
According to https://docs.python.org/3/library/locale.html , LC_ALL is not a legal argument to getlocale. I'm not sure why I didn't see this error before, but now it's blocking my pyblosxom-cmd staticrender --incremental from working.
I'm not entirely sure what the locale change is doing there, but the comment says it's related to date formatting, so I changed it to LC_TIME.

I also made a small change allowing a new config variable "entryext" to specify an extension other than .txt for each blog entries. They aren't txt, they're html-without-headers, and people may want to use .html or some other extension (I've always used .blx, so I set py["entryext"] = "blx" in config.py) so their editor can adjust its settings appropriately.

Sorry for combining the two separate issues; I had hoped to do separate pull requests from the two separate check-ins but apparently a PR has to include everything on a branch. I can understand if you don't want to take the entryext patch, though of course I hope that you will take both of them.